### PR TITLE
Fix AddNumberContext mock wiring

### DIFF
--- a/UnitTestImprovementProject/Models/AddNumberContext.cs
+++ b/UnitTestImprovementProject/Models/AddNumberContext.cs
@@ -1,4 +1,3 @@
-using AutoFixture.Xunit3;
 using ClassToTest;
 using ClassToTest.Interfaces;
 using ClassToTest.Models;
@@ -6,8 +5,26 @@ using Moq;
 
 namespace UnitTestImprovementProject.Models;
 
-public record AddNumberContext(
-    List<Product> Products,
-    [Frozen] Mock<IDependencyClass> DependencyMock,
-    MethodsToTest MethodsToTest,
-    MockSetup MockSetup);
+/// <summary>
+/// Helper context that wires up a <see cref="MethodsToTest"/> instance with a
+/// pre-created <see cref="Mock{IDependencyClass}"/> so the same mock can be
+/// configured and used by the tests.
+/// </summary>
+public class AddNumberContext
+{
+    public AddNumberContext(List<Product> products, Mock<IDependencyClass> dependencyMock, MockSetup mockSetup)
+    {
+        Products = products;
+        DependencyMock = dependencyMock;
+        MockSetup = mockSetup;
+        MethodsToTest = new MethodsToTest(dependencyMock.Object);
+    }
+
+    public List<Product> Products { get; }
+
+    public Mock<IDependencyClass> DependencyMock { get; }
+
+    public MethodsToTest MethodsToTest { get; }
+
+    public MockSetup MockSetup { get; }
+}


### PR DESCRIPTION
## Summary
- keep tests simple by constructing `MethodsToTest` with the same mock instance used for setup

## Testing
- `dotnet test` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68857030c92c832ba44e1f06c9a25fb4