### PR TITLE
Fix ReSharper test failure by using xUnit 2

### DIFF
--- a/UnitTestImprovementProject/Attributes/AutoMoqData.cs
+++ b/UnitTestImprovementProject/Attributes/AutoMoqData.cs
@@ -1,6 +1,6 @@
 using AutoFixture;
 using AutoFixture.AutoMoq;
-using AutoFixture.Xunit3;
+using AutoFixture.Xunit2;
 
 namespace UnitTestImprovementProject.Attributes;
 

--- a/UnitTestImprovementProject/UnitTestImprovementProject.csproj
+++ b/UnitTestImprovementProject/UnitTestImprovementProject.csproj
@@ -9,17 +9,16 @@
 
     <ItemGroup>
       <PackageReference Include="AutoFixture.AutoMoq" Version="5.0.0-preview0012" />
-      <PackageReference Include="AutoFixture.Xunit3" Version="5.0.0-preview0012" />
+      <PackageReference Include="AutoFixture.Xunit2" Version="5.0.0-preview0012" />
       <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
       <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="17.14.1" />
       <PackageReference Include="Microsoft.TestPlatform.TestHost" Version="17.14.1" />
       <PackageReference Include="Shouldly" Version="4.3.0" />
-      <PackageReference Include="xunit.runner.visualstudio" Version="3.1.1">
+      <PackageReference Include="xunit" Version="2.4.2" />
+      <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>
-      <PackageReference Include="xunit.v3.common" Version="3.0.0-pre.25" />
-      <PackageReference Include="xunit.v3.extensibility.core" Version="3.0.0-pre.25" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
## Summary
- swap the test project to use AutoFixture.Xunit2
- depend on xUnit 2 packages instead of xUnit 3

## Testing
- `dotnet test --no-build -v minimal` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688577945500832b9f809342b10778ba